### PR TITLE
Timmy/remove accept length cpu

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1792,8 +1792,8 @@ class FlashAttentionBackend(AttentionBackend):
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
             )
             accept_length = spec_info.accept_length[:bs]
-            if spec_info.accept_length_cpu:
-                metadata.max_seq_len_q = max(spec_info.accept_length_cpu) + 1
+            if spec_info.accept_length:
+                metadata.max_seq_len_q = spec_info.accept_length.max().item() + 1
             else:
                 metadata.max_seq_len_q = 1
 

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -272,9 +272,6 @@ class TritonAttnBackend(AttentionBackend):
                 )
             )
             mask_indptr = None
-            # TODO(FIXME): This will trigger an invalid Eagle tree when using
-            # `max(spec_info.accept_length_cpu)`.
-            # It might have been forgotten to update somewhere.
             max_extend_len = torch.max(spec_info.accept_length).item()
             num_kv_splits = None
             attn_logits = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1907,13 +1907,8 @@ class Scheduler(
                     next_token_ids,
                     free_cache_loc_cpu,
                     bid,
-                    num_accepted_tokens,
                     can_run_cuda_graph,
                 ) = self.draft_worker.forward_batch_speculative_generation(batch)
-                bs = batch.batch_size()
-                self.spec_num_total_accepted_tokens += num_accepted_tokens + bs
-                self.spec_num_total_forward_ct += bs
-                self.num_generated_tokens += num_accepted_tokens
 
             if self.pp_group.is_last_rank:
                 batch.output_ids = next_token_ids

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -191,8 +191,6 @@ class EagleVerifyOutput:
     verified_id: torch.Tensor
     # KV indices to free
     free_cache_loc_cpu: Optional[torch.Tensor]
-    # Accepted token length per sequence in a batch in CPU.
-    accept_length_per_req_cpu: List[int]
     # Accepted indices from logits_output.next_token_logits
     accepted_indices: torch.Tensor
 
@@ -340,7 +338,6 @@ class EagleVerifyInput:
                 logits_output=logits_output,
                 verified_id=torch.empty(0, dtype=torch.long, device=batch.device),
                 free_cache_loc_cpu=None,
-                accept_length_per_req_cpu=[],
                 accepted_indices=torch.full(
                     (0, self.spec_steps + 1),
                     -1,
@@ -508,7 +505,6 @@ class EagleVerifyInput:
             draft_input=draft_input,
             logits_output=logits_output,
             verified_id=verified_id,
-            accept_length_per_req_cpu=[],
             accepted_indices=accept_index,
             free_cache_loc_cpu=free_cache_loc_cpu,
         )

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -63,7 +63,6 @@ class EagleDraftInput:
     # shape: (b,)
     verified_id: torch.Tensor = None
     accept_length: torch.Tensor = None
-    accept_length_cpu: List[int] = None
 
     # Inputs for the attention backends
     # shape: (b + 1,)
@@ -100,7 +99,6 @@ class EagleDraftInput:
             topk_index=torch.empty((0, topk), device=device, dtype=torch.int64),
             capture_hidden_mode=capture_hidden_mode,
             accept_length=torch.empty((0,), device=device, dtype=torch.int32),
-            accept_length_cpu=[],
         )
 
     def prepare_extend_after_decode(
@@ -110,8 +108,6 @@ class EagleDraftInput:
     ):
         batch.forward_mode = ForwardMode.DRAFT_EXTEND
         batch.input_ids = self.verified_id
-        batch.extend_lens = [x + 1 for x in batch.spec_info.accept_length_cpu]
-        batch.extend_num_tokens = sum(batch.extend_lens)
         batch.seq_lens = batch.spec_info.seq_lens_for_draft_extend
         batch.req_pool_indices = batch.spec_info.req_pool_indices_for_draft_extend
         batch.return_logprob = False
@@ -505,7 +501,6 @@ class EagleVerifyInput:
         draft_input.hidden_states = batch.spec_info.hidden_states[accept_index]
         draft_input.verified_id = verified_id
         draft_input.accept_length = accept_length
-        draft_input.accept_length_cpu = accept_length.tolist()
         draft_input.seq_lens_for_draft_extend = batch.seq_lens
         draft_input.req_pool_indices_for_draft_extend = batch.req_pool_indices
 
@@ -513,7 +508,7 @@ class EagleVerifyInput:
             draft_input=draft_input,
             logits_output=logits_output,
             verified_id=verified_id,
-            accept_length_per_req_cpu=draft_input.accept_length_cpu,
+            accept_length_per_req_cpu=[],
             accepted_indices=accept_index,
             free_cache_loc_cpu=free_cache_loc_cpu,
         )

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -297,7 +297,7 @@ class EAGLEWorker(TpModelWorker):
 
     def forward_batch_speculative_generation(
         self, batch: ScheduleBatch
-    ) -> Tuple[LogitsProcessorOutput, torch.Tensor, Optional[torch.Tensor], int, int, bool]:
+    ) -> Tuple[LogitsProcessorOutput, torch.Tensor, Optional[torch.Tensor], int, bool]:
         """Run speculative decoding forward.
 
         NOTE: Many states of batch is modified as you go through. It is not guaranteed that
@@ -318,7 +318,7 @@ class EAGLEWorker(TpModelWorker):
                 self.forward_draft_extend(
                     batch, logits_output.hidden_states, next_token_ids, seq_lens_cpu
                 )
-            return logits_output, next_token_ids, None, bid, 0, False
+            return logits_output, next_token_ids, None, bid, False
         else:
             with self.draft_tp_context(self.draft_model_runner.tp_group):
                 spec_info = self.draft(batch)
@@ -336,7 +336,6 @@ class EAGLEWorker(TpModelWorker):
                 verify_output.verified_id,
                 verify_output.free_cache_loc_cpu,
                 model_worker_batch.bid,
-                sum(verify_output.accept_length_per_req_cpu),
                 can_run_cuda_graph,
             )
 
@@ -781,6 +780,7 @@ class EAGLEWorker(TpModelWorker):
         forward_batch = ForwardBatch.init_new(
             model_worker_batch, self.draft_model_runner
         )
+        forward_batch.extend_seq_lens = batch.spec_info.accept_length
         if forward_batch.seq_lens_cpu is not None:
             forward_batch.seq_lens_sum = forward_batch.seq_lens_cpu.sum().item()
         else:

--- a/python/sglang/srt/speculative/eagle_worker_overlap_thread.py
+++ b/python/sglang/srt/speculative/eagle_worker_overlap_thread.py
@@ -127,7 +127,6 @@ class EAGLEWorkerClient:
                 next_token_ids,
                 free_cache_loc_cpu,
                 bid,
-                _,
                 can_run_cuda_graph,
             ) = self.worker.forward_batch_speculative_generation(batch)
 
@@ -183,7 +182,7 @@ class EAGLEWorkerClient:
 
     def forward_batch_speculative_generation(
         self, batch: ScheduleBatch
-    ) -> Tuple[None, torch.Tensor, int, int, bool]:
+    ) -> Tuple[None, torch.Tensor, Optional[torch.Tensor], int, bool]:
         # Create a new copy of sampling_info because it will be updated in-place by the scheduler for the next batch.
         sampling_info = batch.sampling_info
         batch.sampling_info = self.cur_sampling_info = dataclasses.replace(
@@ -213,7 +212,7 @@ class EAGLEWorkerClient:
             self.future_token_ids_ct + max_spec_tokens
         ) % self.future_token_ids_limit
 
-        return None, future_next_token_ids, -1, 0, False
+        return None, future_next_token_ids, None, -1, False
 
     def get_worker_info(self):
         return self.worker.get_worker_info()


### PR DESCRIPTION
Remove the `accept_length_cpu` field, along with two downstream references:
1. Skip CPU representation of `SchduleBatch.extend_lens`
2. Calculate the number of accepted tokens in the scheduler batch process function instead