### PR TITLE
seq lens cpu caching (tested)

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -831,6 +831,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     # The sum of all sequence lengths
     seq_lens_sum: int = None
+    seq_lens_cpu: Optional[torch.Tensor] = None
 
     # For DP attention
     global_num_tokens: Optional[List[int]] = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1902,6 +1902,12 @@ class Scheduler(
                     )
                 bid = model_worker_batch.bid
             else:
+                # TODO (timmy): move this to model_worker_batch
+                batch.seq_lens_cpu = batch.seq_lens.cpu()
+                if self.enable_overlap:
+                    # Optimistically estimate the seq_lens_cpu for the next draft forward
+                    batch.seq_lens_cpu.add_(self.server_args.speculative_num_steps + 1)
+
                 (
                     logits_output,
                     next_token_ids,

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -493,6 +493,8 @@ class EagleVerifyInput:
             next_power_of_2(bs),
         )
         batch.seq_lens.add_(accept_length + 1)
+        # Optimistically estimate the seq_lens_cpu for the next draft forward
+        batch.seq_lens_cpu.add_(self.spec_steps + 1)
 
         draft_input = EagleDraftInput()
         draft_input.hidden_states = batch.spec_info.hidden_states[accept_index]


### PR DESCRIPTION
Read the `seq_lens` to CPU in the scheduler and persist the CPU buffer throughout the entire eagle pipeline. When number of accepted tokens is unknown, assume maximum acceptance.