### PR TITLE
Fix seq_lens race

### DIFF
--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -236,7 +236,7 @@ class SchedulerOutputProcessorMixin:
                 batch.seq_lens.add_(logits_output.accept_length + 1)
 
             accept_length = logits_output.accept_length.tolist()
-            idx_to_batch = [i for i, length in enumerate(accept_length) for _ in range(length)]
+            idx_to_batch = [i for i, length in enumerate(accept_length) for _ in range(length + 1)]
         else:
             idx_to_batch = list(range(len(batch.reqs)))
 

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -231,6 +231,8 @@ class SchedulerOutputProcessorMixin:
             self.token_to_kv_pool_allocator.free(free_cache_loc_cpu.to("cuda", non_blocking=True))
 
         if self.spec_algorithm.is_eagle():
+            batch.seq_lens.add_(logits_output.accept_length + 1)
+
             accept_length = logits_output.accept_length.tolist()
             idx_to_batch = [i for i, length in enumerate(accept_length) for _ in range(length)]
         else:

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -231,7 +231,9 @@ class SchedulerOutputProcessorMixin:
             self.token_to_kv_pool_allocator.free(free_cache_loc_cpu.to("cuda", non_blocking=True))
 
         if self.spec_algorithm.is_eagle():
-            batch.seq_lens.add_(logits_output.accept_length + 1)
+            # TODO (timmy): when does this happen?
+            if batch.seq_lens is not None:
+                batch.seq_lens.add_(logits_output.accept_length + 1)
 
             accept_length = logits_output.accept_length.tolist()
             idx_to_batch = [i for i, length in enumerate(accept_length) for _ in range(length)]

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -634,7 +634,7 @@ class EAGLEWorker(TpModelWorker):
             res.accepted_indices
         ]
         logits_output.hidden_states = logits_output.hidden_states[res.accepted_indices]
-        logits_output.accept_length = res.draft_input.accept_length
+        logits_output.accept_length = res.draft_input.accept_length.clone()
 
         # Prepare the batch for the next draft forwards.
         batch.forward_mode = (

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -338,6 +338,9 @@ class EAGLEWorker(TpModelWorker):
                 )
             return logits_output, next_token_ids, None, bid, False, batch.spec_info
         else:
+            # Clone seq_lens because it will be modified in-place by verify
+            batch.seq_lens = batch.seq_lens.clone()
+
             with self.draft_tp_context(self.draft_model_runner.tp_group):
                 spec_info = self.draft(batch)
             logits_output, verify_output, can_run_cuda_graph = (

--- a/python/sglang/srt/speculative/eagle_worker.py
+++ b/python/sglang/srt/speculative/eagle_worker.py
@@ -682,11 +682,6 @@ class EAGLEWorker(TpModelWorker):
     def forward_draft_extend_after_decode(self, batch: ModelWorkerBatch):
         assert isinstance(batch.spec_info, EagleDraftInput)
         # Backup fields that will be modified in-place
-        seq_lens_backup = batch.seq_lens.clone()
-        req_pool_indices_backup = batch.req_pool_indices
-        accept_length_backup = batch.spec_info.accept_length
-        return_logprob_backup = batch.return_logprob
-
         input_is_idle = batch.forward_mode.is_idle()
 
         if not input_is_idle and batch.spec_info.verified_id.numel() == 0:
@@ -759,15 +754,9 @@ class EAGLEWorker(TpModelWorker):
 
         self._detect_nan_if_needed(logits_output)
 
-        # Restore backup.
-        # This is because `seq_lens` can be modified in `prepare_extend_after_decode`
         batch.forward_mode = (
             ForwardMode.DECODE if not input_is_idle else ForwardMode.IDLE
         )
-        batch.seq_lens = seq_lens_backup
-        batch.req_pool_indices = req_pool_indices_backup
-        batch.spec_info.accept_length = accept_length_backup
-        batch.return_logprob = return_logprob_backup
 
     def capture_for_decode(
         self, logits_output: LogitsProcessorOutput, draft_input: EagleDraftInput


### PR DESCRIPTION
`seq_lens` has a potential race condition:

1. The forward thread updates `model_worker_batch.seq_lens` by the accept length as determined in `EagleVerifyInput.verify()`. This is an alias to `batch.seq_lens`.
2. The scheduler thread copies `batch.seq_lens` to `model_worker_batch.seq_lens_cpu` for next batch in `run_batch()`

This PR fixes the race condition by creating a copy for model_worker_batch