### PR TITLE
fused mrope

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding.py
+++ b/python/sglang/srt/layers/rotary_embedding.py
@@ -1029,6 +1029,7 @@ class MRotaryEmbedding(RotaryEmbedding):
                     f"Corrected mrope_section: {self.mrope_section} (sum={sum(self.mrope_section)})"
                 )
 
+    @torch.compile(dynamic=True)
     def forward(
         self,
         positions: torch.Tensor,


### PR DESCRIPTION
mrope operation was not fused before. Naively fusing the operation with `torch.compile` decreases mrope time by ~20x.

on an H100:

```
SGLang Compile End-to-End Time Stats:
  mean    : 1.4252
  variance: 0.2898
  p50     : 1.3606
  p90     : 2.0263
  p95     : 2.2614
  p99     : 2.9603
```
  
vs

```
SGLang Overlap End-to-End Time Stats:
  mean    : 1.7880
  variance: 0.4476
  p50     : 1.7804
  p90     : 2.4288
  p95     : 2.7994
  p99     : 3.7799
```