### PR TITLE
Pr16818

### DIFF
--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -117,16 +117,8 @@ class DFlashAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-
-        q, k = apply_qk_norm(
-            q=q,
-            k=k,
-            q_norm=self.q_norm,
-            k_norm=self.k_norm,
-            head_dim=self.head_dim,
-        )
+        q, k = apply_qk_norm(q, k, self.q_norm, self.k_norm, self.head_dim)
         q, k = self.rotary_emb(positions, q, k)
-
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output

--- a/python/sglang/srt/speculative/triton_ops/__init__.py
+++ b/python/sglang/srt/speculative/triton_ops/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Triton kernels for speculative decoding."""
+
+from sglang.srt.speculative.triton_ops.fused_kv_materialize import (
+    FusedKVMaterializeHelper,
+)
+
+__all__ = ["FusedKVMaterializeHelper"]

--- a/python/sglang/srt/speculative/triton_ops/fused_kv_materialize.py
+++ b/python/sglang/srt/speculative/triton_ops/fused_kv_materialize.py
@@ -1,0 +1,246 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Fused Triton kernel for DFlash KV materialization.
+
+Combines: KV projection (cuBLAS) + RMSNorm + RoPE + KV cache write (Triton).
+"""
+
+from typing import List
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fused_norm_rope_write_kernel(
+    kv_ptr,  # [total_ctx, kv_size * 2]
+    k_norm_weight_ptr,  # [head_dim]
+    cos_sin_cache_ptr,  # [max_pos, rotary_dim]
+    positions_ptr,  # [total_ctx]
+    cache_loc_ptr,  # [total_ctx]
+    k_cache_ptr,  # [total_slots, num_kv_heads, head_dim]
+    v_cache_ptr,  # [total_slots, num_kv_heads, head_dim]
+    kv_stride_ctx,
+    cos_sin_stride_pos,
+    k_cache_stride_slot,
+    k_cache_stride_head,
+    v_cache_stride_slot,
+    v_cache_stride_head,
+    total_ctx,
+    num_kv_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    kv_size: tl.constexpr,
+    rotary_dim: tl.constexpr,
+    half_rotary_dim: tl.constexpr,
+    eps: tl.constexpr,
+    BLOCK_HD: tl.constexpr,
+):
+    """Fused RMSNorm(K) + RoPE(K) + cache write. Grid: (total_ctx, num_kv_heads)."""
+    ctx_id = tl.program_id(0)
+    head_id = tl.program_id(1)
+    if ctx_id >= total_ctx:
+        return
+
+    # Load metadata
+    position = tl.load(positions_ptr + ctx_id)
+    cache_loc = tl.load(cache_loc_ptr + ctx_id)
+
+    # Compute base pointers
+    kv_base = kv_ptr + ctx_id * kv_stride_ctx
+    k_base = kv_base + head_id * head_dim
+    v_base = kv_base + kv_size + head_id * head_dim
+    k_write = (
+        k_cache_ptr + cache_loc * k_cache_stride_slot + head_id * k_cache_stride_head
+    )
+    v_write = (
+        v_cache_ptr + cache_loc * v_cache_stride_slot + head_id * v_cache_stride_head
+    )
+
+    # Load K and V
+    offs = tl.arange(0, BLOCK_HD)
+    mask_hd = offs < head_dim
+    mask_half = offs < half_rotary_dim
+
+    k_raw = tl.load(k_base + offs, mask=mask_hd, other=0.0).to(tl.float32)
+    v_raw = tl.load(v_base + offs, mask=mask_hd, other=0.0)
+
+    # RMSNorm on K
+    inv_rms = tl.rsqrt(tl.sum(k_raw * k_raw) / head_dim + eps)
+    norm_w = tl.load(k_norm_weight_ptr + offs, mask=mask_hd, other=1.0).to(tl.float32)
+    k_normed = k_raw * inv_rms * norm_w
+
+    # RoPE (neox style): k_first, k_second -> rotated
+    cos_sin_base = cos_sin_cache_ptr + position * cos_sin_stride_pos
+    cos_v = tl.load(cos_sin_base + offs, mask=mask_half, other=1.0).to(tl.float32)
+    sin_v = tl.load(
+        cos_sin_base + half_rotary_dim + offs, mask=mask_half, other=0.0
+    ).to(tl.float32)
+
+    # Extract first/second halves of K for rotation
+    k_first = tl.where(mask_half, k_normed, 0.0)
+    k_second_raw = tl.load(
+        k_base + half_rotary_dim + offs, mask=mask_half, other=0.0
+    ).to(tl.float32)
+    norm_w_second = tl.load(
+        k_norm_weight_ptr + half_rotary_dim + offs, mask=mask_half, other=1.0
+    ).to(tl.float32)
+    k_second = k_second_raw * inv_rms * norm_w_second
+
+    # Apply rotation
+    k_rot_first = k_first * cos_v - k_second * sin_v
+    k_rot_second = k_second * cos_v + k_first * sin_v
+
+    # Store V (no transform)
+    tl.store(v_write + offs, v_raw, mask=mask_hd)
+
+    # Store K: rotated halves + pass-through
+    tl.store(k_write + offs, k_rot_first.to(v_raw.dtype), mask=mask_half)
+    tl.store(
+        k_write + half_rotary_dim + offs, k_rot_second.to(v_raw.dtype), mask=mask_half
+    )
+    mask_pass = (offs >= rotary_dim) & (offs < head_dim)
+    tl.store(k_write + offs, k_normed.to(v_raw.dtype), mask=mask_pass)
+
+
+def _fused_norm_rope_write(
+    kv: torch.Tensor,  # [total_ctx, kv_size*2]
+    k_norm_weight: torch.Tensor,  # [head_dim]
+    cos_sin_cache: torch.Tensor,  # [max_pos, rotary_dim]
+    positions: torch.Tensor,  # [total_ctx]
+    cache_locs: torch.Tensor,  # [total_ctx]
+    k_cache: torch.Tensor,  # [total_slots, num_kv_heads, head_dim]
+    v_cache: torch.Tensor,  # [total_slots, num_kv_heads, head_dim]
+    num_kv_heads: int,
+    head_dim: int,
+    rotary_dim: int,
+    eps: float = 1e-6,
+) -> None:
+    """Fused RMSNorm + RoPE + cache write for a single layer."""
+    total_ctx = kv.shape[0]
+    if total_ctx == 0:
+        return
+
+    kv_size = num_kv_heads * head_dim
+    half_rotary_dim = rotary_dim // 2
+    BLOCK_HD = triton.next_power_of_2(head_dim)
+
+    # Ensure int64 for indexing
+    if positions.dtype != torch.int64:
+        positions = positions.to(torch.int64)
+    if cache_locs.dtype != torch.int64:
+        cache_locs = cache_locs.to(torch.int64)
+
+    _fused_norm_rope_write_kernel[(total_ctx, num_kv_heads)](
+        kv,
+        k_norm_weight,
+        cos_sin_cache,
+        positions,
+        cache_locs,
+        k_cache,
+        v_cache,
+        kv.stride(0),
+        cos_sin_cache.stride(0),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        v_cache.stride(0),
+        v_cache.stride(1),
+        total_ctx,
+        num_kv_heads,
+        head_dim,
+        kv_size,
+        rotary_dim,
+        half_rotary_dim,
+        eps,
+        BLOCK_HD,
+    )
+
+
+class FusedKVMaterializeHelper:
+    """Fused KV materialization helper using batched projection.
+
+    Uses torch.einsum for batched KV projection across all layers,
+    then a Triton kernel for fused RMSNorm + RoPE + cache write per layer.
+    """
+
+    def __init__(
+        self,
+        layers: List,
+        rotary_emb,
+        num_kv_heads: int,
+        head_dim: int,
+        device: torch.device,
+    ):
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.rotary_emb = rotary_emb
+        self.n_layers = len(layers)
+        self.device = device
+
+        # Pre-extract and stack weights for batched projection
+        kv_weights = []
+        self.k_norm_weights = []
+        self.eps_values = []
+
+        for layer in layers:
+            attn = layer.self_attn
+            # Extract KV portion of QKV weight
+            qkv_w = attn.qkv_proj.weight
+            kv_weight = qkv_w[attn.q_size : attn.q_size + 2 * attn.kv_size]
+            kv_weights.append(kv_weight)
+            self.k_norm_weights.append(attn.k_norm.weight)
+            self.eps_values.append(attn.k_norm.variance_epsilon)
+
+        # Stack for batched einsum: [n_layers, kv_size*2, hidden_size]
+        self.batched_kv_weight = torch.stack(kv_weights)
+
+        self.rotary_dim = getattr(rotary_emb, "rotary_dim", head_dim)
+        self.is_neox_style = getattr(rotary_emb, "is_neox_style", True)
+
+        if not self.is_neox_style:
+            raise NotImplementedError("Only neox-style RoPE is supported.")
+
+    def materialize(
+        self,
+        ctx_hidden: torch.Tensor,
+        positions: torch.Tensor,
+        cache_locs: torch.Tensor,
+        k_cache_buffers: List[torch.Tensor],
+        v_cache_buffers: List[torch.Tensor],
+    ) -> None:
+        """Materialize KV cache for all layers using batched projection."""
+        total_ctx = ctx_hidden.shape[0]
+        if total_ctx == 0:
+            return
+
+        cos_sin_cache = self.rotary_emb.cos_sin_cache
+
+        # Batched KV projection: [n_layers, total_ctx, kv_size*2]
+        kv_all = torch.einsum("th,loh->lto", ctx_hidden, self.batched_kv_weight)
+
+        # Per-layer fused norm/RoPE/write
+        for layer_id in range(self.n_layers):
+            _fused_norm_rope_write(
+                kv_all[layer_id],
+                self.k_norm_weights[layer_id],
+                cos_sin_cache,
+                positions,
+                cache_locs,
+                k_cache_buffers[layer_id],
+                v_cache_buffers[layer_id],
+                self.num_kv_heads,
+                self.head_dim,
+                self.rotary_dim,
+                self.eps_values[layer_id],
+            )


### PR DESCRIPTION
## Summary

This PR introduces a fused Triton kernel for DFlash's KV materialization step.

## Changes

### New Fused Kernel (`python/sglang/srt/speculative/triton_ops/fused_kv_materialize.py`)
- Batched KV projection across all draft model layers using `torch.einsum`
- Fused RMSNorm (K normalization) + RoPE + KV cache write in a Triton kernel
- ~5x speedup for the KV materialization step, translating to ~3% end-to-end throughput improvement

### Auto-enabled by Default
- Fused kernel is automatically enabled when `--speculative-algorithm DFLASH` is used
- Added `--disable-speculative-dflash-fused-kv` flag to disable for benchmarking/debugging

### Benchmark Integration
- Updated `bench_dflash_gsm8k_sweep.py` with `--compare-fused-kv` flag to compare all three configurations:
  - Baseline (no speculative decoding)
  - DFLASH with unfused KV materialization
  - DFLASH with fused KV materialization (default)

## Files Changed
- `python/sglang/srt/speculative/triton_ops/fused_kv_materialize.py` (new)
- `python/sglang/srt/speculative/triton_ops/__init__.py` (new)
- `python/sglang/srt/speculative/dflash_worker.py` (integration)
- `python/sglang/srt/server_args.py` (new flag)
- `benchmark/dflash/bench_dflash_gsm8k_sweep.py` (benchmark update)
- Other linting edits generated by pre-commits following SGLang contribution guide

## Benchmark Results

# DFLASH Comparison (Baseline vs Unfused vs Fused)

## Settings
- target_model: `Qwen/Qwen3-8B`
- draft_model: `z-lab/Qwen3-8B-DFlash-b16`
- prompt_style: `chat`
- max_new_tokens: `2048`
- attention_backends: `flashinfer, fa3`
- tp_sizes: `1`
- concurrencies: `1, 8, 16, 32`
- device_sm: `90`

## Backend: `flashinfer`

### Baseline (tok/s)
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 181.94 | 1,275.62 | 2,372.95 | 3,709.31 |

### DFLASH Unfused (tok/s)
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 650.91 | 3,591.49 | 5,092.57 | 6,084.77 |

### DFLASH Fused (tok/s)
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 674.19 | 3,675.70 | 5,262.18 | 6,296.22 |

### Speedup: Unfused vs Baseline
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 3.578 | 2.815 | 2.146 | 1.640 |

### Speedup: Fused vs Baseline
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 3.706 | 2.881 | 2.218 | 1.697 |

### Speedup: Fused vs Unfused
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 1.036 | 1.023 | 1.033 | 1.035 |

### Accuracy (Unfused / Fused)
- tp=1, conc=1: 0.844 / 0.844
- tp=1, conc=8: 0.865 / 0.869
- tp=1, conc=16: 0.865 / 0.867
- tp=1, conc=32: 0.859 / 0.857

## Backend: `fa3`

### Baseline (tok/s)
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 182.91 | 1,300.92 | 2,488.75 | 4,316.13 |

### DFLASH Unfused (tok/s)
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 670.21 | 3,977.76 | 5,850.07 | 7,149.59 |

### DFLASH Fused (tok/s)
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 695.60 | 4,100.70 | 5,965.76 | 7,306.07 |

### Speedup: Unfused vs Baseline
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 3.664 | 3.058 | 2.351 | 1.656 |

### Speedup: Fused vs Baseline
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 3.803 | 3.152 | 2.397 | 1.693 |

### Speedup: Fused vs Unfused
| tp\conc | 1 | 8 | 16 | 32 |
| --- | --- | --- | --- | --- |
| 1 | 1.038 | 1.031 | 1.020 | 1.022 |

### Accuracy (Unfused / Fused)
- tp=1, conc=1: 0.852 / 0.852
- tp=1, conc=8: 0.852 / 0.855
- tp=1, conc=16: 0.855 / 0.852
- tp=1, conc=32: 0.854 / 0.854

